### PR TITLE
Don't add support module macro to MASTER_RELEASE. Just do it locally …

### DIFF
--- a/utils/ioc_utils.py
+++ b/utils/ioc_utils.py
@@ -106,6 +106,19 @@ def _add_to_ioc_makefile(name):
     add_to_makefile_list(IOC_ROOT, "IOCDIRS", name)
 
 
+def _add_macro_to_release_file(device_info):
+    """
+    Adds a macro for the support directory to IOC release file
+
+    Args:
+        device_info: Name-based device information
+    """
+    logging.info("Adding macro to MASTER_RELEASE")
+    with open(path.join(device_info.ioc_path(), "configure", "RELEASE"), "a") as f:
+        f.write("{macro}=$(SUPPORT)/{name}/master\n".format(
+            macro=device_info.ioc_name(), name=device_info.support_app_name()))
+
+
 def create_ioc(device_info, device_count):
     """
     Creates a vanilla IOC in the EPICS IOC submodule
@@ -130,3 +143,4 @@ def create_ioc(device_info, device_count):
     _clean_up(device_info.ioc_path())
     _build(device_info.ioc_path())
     _add_to_ioc_makefile(device_info.ioc_name())
+    _add_macro_to_release_file()

--- a/utils/support_utils.py
+++ b/utils/support_utils.py
@@ -18,20 +18,6 @@ def _add_to_makefile(name):
     add_to_makefile_list(EPICS_SUPPORT, "SUPPDIRS", name)
 
 
-def _add_macro(device_info):
-    """
-    Adds a macro to MASTER_RELEASE
-
-    Args:
-        device_info: Name-based device information
-    """
-    logging.info("Adding macro to MASTER_RELEASE")
-    with open(EPICS_MASTER_RELEASE, "a") as f:
-        f.write("# Auto-generated macro for {}\n".format(device_info.log_name()))
-        f.write("{macro}=$(SUPPORT)/{name}/master\n".format(
-            macro=device_info.ioc_name(), name=device_info.support_app_name()))
-
-
 def create_submodule(device_info):
     """
     Creates a submodule and links it into the main EPICS repo
@@ -47,7 +33,6 @@ def create_submodule(device_info):
     RepoWrapper(EPICS).create_submodule(device_info.support_app_name(), device_info.support_repo_url(), master_dir)
     logging.info("Initializing device support repository {}".format(master_dir))
     _add_to_makefile(device_info.support_app_name())
-    _add_macro(device_info)
 
 
 def apply_support_dir_template(device_info):


### PR DESCRIPTION
### Description of work

I've changed how build dependencies are set up. Rather than adding a macro to MASTER_RELEASE, it is now added directly to the RELEASE file of the IOC. That way, only the IOC will depend on the respective support module.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2893

## Acceptance tests

As on EPICS-BASE PR: https://github.com/ISISComputingGroup/EPICS-base/pull/22

## Other checks

- [x] Have you updated the [IOC creation page](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Creating-an-ISIS-StreamDevice-IOC) to reflect the steps performed by the script?
