### PR TITLE
Ticket6775_IOC_Generator_Lewis_emulator_folder_structure_generated_incorrectly

### DIFF
--- a/templates/support/system_tests/lewis_emulators/DEVICENAME/interfaces/stream_interface.py
+++ b/templates/support/system_tests/lewis_emulators/DEVICENAME/interfaces/stream_interface.py
@@ -1,8 +1,7 @@
-from lewis.adapters.stream import StreamInterface
+from lewis.adapters.stream import StreamInterface, Cmd
+from lewis.utils.command_builder import CmdBuilder
 from lewis.core.logging import has_log
-
-from lewis_emulators.utils.command_builder import CmdBuilder
-from lewis_emulators.utils.replies import conditional_reply
+from lewis.utils.replies import conditional_reply
 
 
 @has_log

--- a/utils/emulator_utils.py
+++ b/utils/emulator_utils.py
@@ -42,5 +42,5 @@ def create_emulator(device_info):
     Args:
         device_info: Provides name-based information about the device
     """
-    _copy_files(device_info.emulator_dir())
-    _replace_default_name(device_info.emulator_dir(), device_info.emulator_name())
+    _copy_files(os.path.abspath(os.path.join(device_info.emulator_dir(), os.pardir)))
+    _replace_default_name(os.path.abspath(os.path.join(device_info.emulator_dir(), os.pardir)), device_info.emulator_name())


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/6775
Fixed problems preventing emulator from being usable right after creation using generaton