### PR TITLE
remove constructor - this made terminators go weird

### DIFF
--- a/templates/support/system_tests/lewis_emulators/DEVICENAME/interfaces/stream_interface.py
+++ b/templates/support/system_tests/lewis_emulators/DEVICENAME/interfaces/stream_interface.py
@@ -6,11 +6,7 @@ from lewis.utils.replies import conditional_reply
 
 @has_log
 class DEVICENAMEStreamInterface(StreamInterface):
-
-    def __init__(self):
-        super(DEVICENAMEStreamInterface, self).__init__()
-        # Commands that we expect via serial during normal operation
-        self.commands = {
+    commands = {
             CmdBuilder(self.catch_all).arg("^#9.*$").build()  # Catch-all command for debugging
         }
 

--- a/templates/support/system_tests/lewis_emulators/DEVICENAME/interfaces/stream_interface.py
+++ b/templates/support/system_tests/lewis_emulators/DEVICENAME/interfaces/stream_interface.py
@@ -7,7 +7,7 @@ from lewis.utils.replies import conditional_reply
 @has_log
 class DEVICENAMEStreamInterface(StreamInterface):
     commands = {
-            CmdBuilder(self.catch_all).arg("^#9.*$").build()  # Catch-all command for debugging
+            CmdBuilder("catch_all").arg("^#9.*$").build()  # Catch-all command for debugging
         }
 
     def handle_error(self, request, error):


### PR DESCRIPTION
doesn't seem to properly override the terminators - we saw this when david used the generator for the RP100

## Acceptance tests

- [ ] Have you updated the [IOC creation page](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Creating-an-ISIS-StreamDevice-IOC) to reflect the steps performed by the script?
