### PR TITLE
give default terminators so people don't put them in the __init__ by …

### DIFF
--- a/templates/support/system_tests/lewis_emulators/DEVICENAME/interfaces/stream_interface.py
+++ b/templates/support/system_tests/lewis_emulators/DEVICENAME/interfaces/stream_interface.py
@@ -6,6 +6,9 @@ from lewis.utils.replies import conditional_reply
 
 @has_log
 class DEVICENAMEStreamInterface(StreamInterface):
+    
+        in_terminator = "\r\n"
+        out_terminator = "\r\n"
 
     def __init__(self):
         super(DEVICENAMEStreamInterface, self).__init__()

--- a/templates/support/system_tests/lewis_emulators/DEVICENAME/interfaces/stream_interface.py
+++ b/templates/support/system_tests/lewis_emulators/DEVICENAME/interfaces/stream_interface.py
@@ -7,8 +7,8 @@ from lewis.utils.replies import conditional_reply
 @has_log
 class DEVICENAMEStreamInterface(StreamInterface):
     
-        in_terminator = "\r\n"
-        out_terminator = "\r\n"
+    in_terminator = "\r\n"
+    out_terminator = "\r\n"
 
     def __init__(self):
         super(DEVICENAMEStreamInterface, self).__init__()


### PR DESCRIPTION
…accident

if you put the terminators in __init__ they don't override, even with `self` - putting in here to make more obvious

## Acceptance tests

- [ ] Have you updated the [IOC creation page](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Creating-an-ISIS-StreamDevice-IOC) to reflect the steps performed by the script?
