### PR TITLE
Support non-standard epics directory names

### DIFF
--- a/system_paths.py
+++ b/system_paths.py
@@ -1,17 +1,17 @@
 """ Standard system paths used in the IBEX distribution """
+from os import getenv
 from os.path import join
 
 INSTRUMENT = join("C:\\", "Instrument")
-EPICS = join(INSTRUMENT, "Apps", "EPICS")
+EPICS = getenv("EPICS_KIT_ROOT", join(INSTRUMENT, "Apps", "EPICS"))
 
 IOC_ROOT = join(EPICS, "IOC", "master")
 PERL = join("C:\\", "Strawberry", "perl", "bin", "perl.exe")
 EPICS_BASE_BUILD = join(EPICS, "base", "master", "bin")
-ARCHITECTURE = "windows-x64"
+ARCHITECTURE = getenv("EPICS_HOST_ARCH", "windows-x64")
 PERL_IOC_GENERATOR = join(EPICS_BASE_BUILD, ARCHITECTURE, "makeBaseApp.pl")
 
 EPICS_SUPPORT = join(EPICS, "support")
-EPICS_MASTER_RELEASE = join(EPICS, "configure", "MASTER_RELEASE")
 
 CLIENT = join(INSTRUMENT, "Dev", "ibex_gui")
 CLIENT_SRC = join(CLIENT, "base")

--- a/tests/test_system_path.py
+++ b/tests/test_system_path.py
@@ -11,7 +11,7 @@ class SystemPathTests(unittest.TestCase):
         # Arrange
         paths = (
             INSTRUMENT, EPICS, IOC_ROOT, PERL, EPICS_BASE_BUILD, PERL_IOC_GENERATOR, EPICS_SUPPORT,
-            EPICS_MASTER_RELEASE, CLIENT_SRC, CLIENT, OPI_RESOURCES,
+            CLIENT_SRC, CLIENT, OPI_RESOURCES,
             PERL_SUPPORT_GENERATOR
         )
 

--- a/utils/ioc_utils.py
+++ b/utils/ioc_utils.py
@@ -113,7 +113,7 @@ def _add_macro_to_release_file(device_info):
     Args:
         device_info: Name-based device information
     """
-    logging.info("Adding macro to MASTER_RELEASE")
+    logging.info("Adding macro to RELEASE")
     with open(path.join(device_info.ioc_path(), "configure", "RELEASE"), "a") as f:
         f.write("{macro}=$(SUPPORT)/{name}/master\n".format(
             macro=device_info.ioc_name(), name=device_info.support_app_name()))

--- a/utils/support_utils.py
+++ b/utils/support_utils.py
@@ -1,5 +1,5 @@
 """ Utilities for adding a template emulator for a new IBEX device"""
-from system_paths import EPICS_SUPPORT, PERL, PERL_SUPPORT_GENERATOR, EPICS, EPICS_MASTER_RELEASE
+from system_paths import EPICS_SUPPORT, PERL, PERL_SUPPORT_GENERATOR, EPICS
 from templates.paths import SUPPORT_MAKEFILE, SUPPORT_GITIGNORE, SUPPORT_GITATTRIBUTES, SUPPORT_LICENCE, DB
 from utils.common_utils import run_command, get_year
 from utils.file_system_utils import append_to_file, mkdir, add_to_makefile_list, replace_in_file, copy_file


### PR DESCRIPTION
Take defaults from existing EPICS environment if they exist, so can be used for multiple epics installs
Remove references to MASTER_RELEASE as outdated

## Acceptance tests

- [ ] Have you updated the [IOC creation page](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Creating-an-ISIS-StreamDevice-IOC) to reflect the steps performed by the script?
