### PR TITLE
Changed method to add new submodules, as gitpython did not allow local branch creation

### DIFF
--- a/IBEX_device_generator.py
+++ b/IBEX_device_generator.py
@@ -18,7 +18,6 @@ def _configure_logging():
     logging.basicConfig(format="%(asctime)-15s, %(levelname)s: %(message)s")
     logging.getLogger().setLevel(logging.INFO)
 
-
 def generate_device(name, ticket, device_count, use_git, github_token):
     """
     Creates the boilerplate components for an IOC

--- a/utils/git_utils.py
+++ b/utils/git_utils.py
@@ -137,13 +137,12 @@ class RepoWrapper(object):
             raise RuntimeError("Error whilst creating initial commit in {}: {}"
                                .format(self._repo.working_dir, e))
 
-    def create_submodule(self, name, url, path, branch):
+    def create_submodule(self, name, url, path):
         """
         Args:
             name: Name of the submodule
             url: Url to the submodule repo
             path: Local system path to the submodule
-            branch: the branch to be written to .gitmodules
         """
         try:
             git_modules_path = join(self._repo.working_tree_dir, ".git", "modules", name)

--- a/utils/git_utils.py
+++ b/utils/git_utils.py
@@ -9,7 +9,7 @@ from utils.file_system_utils import copy_file, mkdir, rmtree
 from os.path import join, exists
 from time import sleep
 import logging
-
+import subprocess
 
 class RepoWrapper(object):
     """
@@ -137,12 +137,13 @@ class RepoWrapper(object):
             raise RuntimeError("Error whilst creating initial commit in {}: {}"
                                .format(self._repo.working_dir, e))
 
-    def create_submodule(self, name, url, path):
+    def create_submodule(self, name, url, path, branch):
         """
         Args:
             name: Name of the submodule
             url: Url to the submodule repo
             path: Local system path to the submodule
+            branch: the branch to be written to .gitmodules
         """
         try:
             git_modules_path = join(self._repo.working_tree_dir, ".git", "modules", name)
@@ -154,11 +155,13 @@ class RepoWrapper(object):
                         "The submodule {} is not part of this repo, yet {} exists. Shall I delete it?"
                         "".format(name, git_modules_path)):
                     rmtree(git_modules_path)
-                self._repo.create_submodule(name, path, url=url, branch="main")
-        except InvalidGitRepositoryError as e:
-            logging.error("Cannot add {} as a submodule, it does not exist: {}".format(path, e))
-        except GitCommandError as e:
-            logging.error("Git command failed to create submodule from {}: {}".format(path, e))
+                branch = "main"
+                # We use subprocess here because gitpython seems to add a /refs/heads/ prefix to any branch you give it,
+                # and this breaks the repo checks. 
+                subprocess.run(f"git submodule add -b {branch} --name {name} {url} {path}", cwd = self._repo.working_tree_dir, check=True)
+                
+        except subprocess.CalledProcessError as e:
+            logging.error("Cannot add {} as a submodule, error: {}".format(path, e))
         except Exception as e:
             raise RuntimeError("Unknown error {} of type {} whilst creating submodule in {}".format(e, type(e), path))
 

--- a/utils/support_utils.py
+++ b/utils/support_utils.py
@@ -34,8 +34,7 @@ def create_submodule(device_info, create_submodule_in_git):
                           "Remove this to be able to create the submodule correctly".format(master_dir))
             exit()
         input(f"Attempting to add submodule using remote {device_info.support_repo_url()}. Press return to confirm it exists")
-        branch = "main"
-        RepoWrapper(EPICS).create_submodule(device_info.support_app_name(), device_info.support_repo_url(), master_dir, branch=branch)
+        RepoWrapper(EPICS).create_submodule(device_info.support_app_name(), device_info.support_repo_url(), master_dir)
     else:
         logging.warning("Because you have chosen no-git the submodule has not been added for your ioc support module. "
                         "If files are added they will be added to EPICS not a submodule of it.")

--- a/utils/support_utils.py
+++ b/utils/support_utils.py
@@ -34,7 +34,8 @@ def create_submodule(device_info, create_submodule_in_git):
                           "Remove this to be able to create the submodule correctly".format(master_dir))
             exit()
         input(f"Attempting to add submodule using remote {device_info.support_repo_url()}. Press return to confirm it exists")
-        RepoWrapper(EPICS).create_submodule(device_info.support_app_name(), device_info.support_repo_url(), master_dir)
+        branch = "main"
+        RepoWrapper(EPICS).create_submodule(device_info.support_app_name(), device_info.support_repo_url(), master_dir, branch=branch)
     else:
         logging.warning("Because you have chosen no-git the submodule has not been added for your ioc support module. "
                         "If files are added they will be added to EPICS not a submodule of it.")


### PR DESCRIPTION
The previous way to create new submodules used gitpython, which automatically will add this "refs/heads/" prefix to any "branch" pased to it.

## Acceptance tests

- [ ] The script generator adds the correct branch name when run to generate a new device submodule.

# To test: 

- create a dummy device, and check that the .gitmodules file has the correct "branch" (should be just "main) in Instrument/Apps/EPICS
