### PR TITLE
Make sure submodule is added as relative path

### DIFF
--- a/utils/git_utils.py
+++ b/utils/git_utils.py
@@ -10,6 +10,7 @@ from os.path import join, exists
 from time import sleep
 import logging
 import subprocess
+import posixpath
 
 class RepoWrapper(object):
     """
@@ -155,9 +156,11 @@ class RepoWrapper(object):
                         "".format(name, git_modules_path)):
                     rmtree(git_modules_path)
                 branch = "main"
+                # create path relative to current root in case path is absolute
+                sub_path = posixpath.relpath(path, start=self._repo.working_tree_dir)
                 # We use subprocess here because gitpython seems to add a /refs/heads/ prefix to any branch you give it,
                 # and this breaks the repo checks. 
-                subprocess.run(f"git submodule add -b {branch} --name {name} {url} {path}", cwd = self._repo.working_tree_dir, check=True)
+                subprocess.run(f"git submodule add -b {branch} --name {name} {url} {sub_path}", cwd = self._repo.working_tree_dir, check=True)
                 
         except subprocess.CalledProcessError as e:
             logging.error("Cannot add {} as a submodule, error: {}".format(path, e))

--- a/utils/git_utils.py
+++ b/utils/git_utils.py
@@ -6,11 +6,10 @@ from git import Repo, GitCommandError, InvalidGitRepositoryError, NoSuchPathErro
 from utils.command_line_utils import ask_do_step
 from templates.paths import SUPPORT_README
 from utils.file_system_utils import copy_file, mkdir, rmtree
-from os.path import join, exists
+from os.path import join, exists, relpath
 from time import sleep
 import logging
 import subprocess
-import posixpath
 
 class RepoWrapper(object):
     """
@@ -157,7 +156,7 @@ class RepoWrapper(object):
                     rmtree(git_modules_path)
                 branch = "main"
                 # create path relative to current root in case path is absolute
-                sub_path = posixpath.relpath(path, start=self._repo.working_tree_dir)
+                sub_path = relpath(path, start=self._repo.working_tree_dir)
                 # We use subprocess here because gitpython seems to add a /refs/heads/ prefix to any branch you give it,
                 # and this breaks the repo checks. 
                 subprocess.run(f"git submodule add -b {branch} --name {name} {url} {sub_path}", cwd = self._repo.working_tree_dir, check=True)


### PR DESCRIPTION
Check submodule path is added as relative, before change it could have a `C:/Instrument/Apps/EPICS` added 

To test

Prior to change the `path = ` of the new submodule in `.gitmodules` will have an absolute `C:/Instrument/Apps/EPICS/support/...` form
Post change it will be a relative `support/...` form